### PR TITLE
Improve APRS forwarding and beacon collision handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -98,7 +98,7 @@ func NewDigiGate(logger *log.Logger) (*DigiGate, error) {
 
 	appCache := cache.NewCache(cfg.CacheSize, ".cache.json")
 
-	multimon = multimonpackage.New(cfg.Multimon, captureOutputChan, ps, appCache, txHandle, logger)
+	multimon = multimonpackage.New(cfg.Multimon, captureOutputChan, ps, appCache, txHandle, cfg.StationCallsign, logger)
 	err = multimon.Start()
 	if err != nil {
 		return nil, fmt.Errorf("Error starting multimon: %v", err)

--- a/config.yml.example
+++ b/config.yml.example
@@ -82,6 +82,10 @@ igate:
     rf-path: "WIDE2-1"
     # Path inserted on APRS-IS frames; qAR + your callsign is common.
     is-path: "TCPIP*,qAR,N0CALL-10"
+    # Optional secondary RF schedules (e.g. direct beacons). Each must be >=10m.
+    additional-rf-beacons:
+    - path: ""
+      interval: 10m
   aprsis:
     # enable to connect to APRS-IS server for iGate
     enabled: false

--- a/config.yml.example
+++ b/config.yml.example
@@ -70,6 +70,9 @@ igate:
     rf-interval: 30m
     # interval for APRS-IS beacons (>=10m). Falls back to "interval" if omitted.
     is-interval: 30m
+    # set to true to suppress RF beaconing or APRS-IS beaconing respectively.
+    disable-rf: false
+    disable-tcp: false
     # optional legacy interval applied to both RF and APRS-IS when the per-path
     # values above are not provided.
     # interval: 30m

--- a/internal/config/cfg.go
+++ b/internal/config/cfg.go
@@ -51,6 +51,8 @@ type (
 		Interval   time.Duration
 		RFInterval time.Duration `yaml:"rf-interval"`
 		ISInterval time.Duration `yaml:"is-interval"`
+		DisableRF  bool          `yaml:"disable-rf"`
+		DisableTCP bool          `yaml:"disable-tcp"`
 		Comment    string
 		RFPath     string `yaml:"rf-path"`
 		ISPath     string `yaml:"is-path"`
@@ -127,6 +129,14 @@ func GetConfig() (Config, error) {
 
 	if cfg.IGate.Beacon.ISInterval <= 0 {
 		cfg.IGate.Beacon.ISInterval = cfg.IGate.Beacon.Interval
+	}
+
+	if cfg.IGate.Beacon.DisableRF {
+		cfg.IGate.Beacon.RFInterval = 0
+	}
+
+	if cfg.IGate.Beacon.DisableTCP {
+		cfg.IGate.Beacon.ISInterval = 0
 	}
 
 	if cfg.Transmitter.TxDelay <= 0 {

--- a/internal/config/cfg.go
+++ b/internal/config/cfg.go
@@ -54,8 +54,9 @@ type (
 		DisableRF  bool          `yaml:"disable-rf"`
 		DisableTCP bool          `yaml:"disable-tcp"`
 		Comment    string
-		RFPath     string `yaml:"rf-path"`
-		ISPath     string `yaml:"is-path"`
+		RFPath     string     `yaml:"rf-path"`
+		ISPath     string     `yaml:"is-path"`
+		ExtraRF    []RFBeacon `yaml:"additional-rf-beacons"`
 	}
 
 	AprsIs struct {
@@ -77,6 +78,11 @@ type (
 		WidePatterns  []string      `yaml:"wide-patterns"`
 		SSnPrefixes   []string      `yaml:"ssn-prefixes"`
 		DedupeWindow  time.Duration `yaml:"dedupe-window"`
+	}
+
+	RFBeacon struct {
+		Path     string        `yaml:"path"`
+		Interval time.Duration `yaml:"interval"`
 	}
 )
 
@@ -137,6 +143,10 @@ func GetConfig() (Config, error) {
 
 	if cfg.IGate.Beacon.DisableTCP {
 		cfg.IGate.Beacon.ISInterval = 0
+	}
+
+	for idx := range cfg.IGate.Beacon.ExtraRF {
+		cfg.IGate.Beacon.ExtraRF[idx].Path = strings.TrimSpace(cfg.IGate.Beacon.ExtraRF[idx].Path)
 	}
 
 	if cfg.Transmitter.TxDelay <= 0 {

--- a/internal/igate/igate_beacon_test.go
+++ b/internal/igate/igate_beacon_test.go
@@ -1,0 +1,154 @@
+package igate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oorrwullie/go-igate/internal/aprs"
+	"github.com/oorrwullie/go-igate/internal/log"
+	"github.com/oorrwullie/go-igate/internal/transmitter"
+)
+
+func setTestBeaconTimings() func() {
+	origQuiet := beaconChannelQuiet
+	origRetry := beaconRetryInterval
+	origCollision := beaconCollisionWindow
+	origWarmup := beaconWarmup
+
+	beaconChannelQuiet = 1 * time.Millisecond
+	beaconRetryInterval = 2 * time.Millisecond
+	beaconCollisionWindow = 15 * time.Millisecond
+	beaconWarmup = 0
+
+	return func() {
+		beaconChannelQuiet = origQuiet
+		beaconRetryInterval = origRetry
+		beaconCollisionWindow = origCollision
+		beaconWarmup = origWarmup
+	}
+}
+
+func TestSendBeaconRfRetriesOnCollision(t *testing.T) {
+	restore := setTestBeaconTimings()
+	defer restore()
+
+	logger, err := log.New()
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	tx := &transmitter.Tx{
+		Chan: make(chan string, 4),
+	}
+
+	ig := &IGate{
+		callSign:    "N0CALL-1",
+		enableTx:    true,
+		tx:          tx,
+		logger:      logger,
+		stop:        make(chan struct{}),
+		forwardChan: make(chan *aprs.Packet, 1),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ig.sendBeaconRf("N0CALL-1>APRS:TestBeacon", "TestBeacon")
+		close(done)
+	}()
+
+	first := waitForTx(t, tx, 200*time.Millisecond)
+	if first == "" {
+		t.Fatalf("expected first beacon transmission")
+	}
+
+	ig.markRx()
+	ig.observeBeacon(&aprs.Packet{
+		Src:     "OTHERCALL",
+		Payload: "TestBeacon",
+	})
+
+	second := waitForTx(t, tx, 200*time.Millisecond)
+	if second == "" || second != first {
+		t.Fatalf("expected retry after collision, got %q", second)
+	}
+
+	ig.markRx()
+	ig.observeBeacon(&aprs.Packet{
+		Src:     "N0CALL-1",
+		Payload: "TestBeacon",
+	})
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("sendBeaconRf did not finish after successful retry")
+	}
+
+	close(ig.stop)
+}
+
+func TestSendBeaconRfSucceedsFirstAttempt(t *testing.T) {
+	restore := setTestBeaconTimings()
+	defer restore()
+
+	logger, err := log.New()
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	tx := &transmitter.Tx{
+		Chan: make(chan string, 2),
+	}
+
+	ig := &IGate{
+		callSign:    "N0CALL-5",
+		enableTx:    true,
+		tx:          tx,
+		logger:      logger,
+		stop:        make(chan struct{}),
+		forwardChan: make(chan *aprs.Packet, 1),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ig.sendBeaconRf("N0CALL-5>APRS:Success", "Success")
+		close(done)
+	}()
+
+	first := waitForTx(t, tx, 200*time.Millisecond)
+	if first == "" {
+		t.Fatalf("expected beacon transmission")
+	}
+
+	ig.markRx()
+	ig.observeBeacon(&aprs.Packet{
+		Src:     "N0CALL-5",
+		Payload: "Success",
+	})
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("sendBeaconRf did not terminate after successful acknowledgment")
+	}
+
+	select {
+	case extra := <-tx.Chan:
+		t.Fatalf("unexpected additional transmission: %q", extra)
+	default:
+	}
+
+	close(ig.stop)
+}
+
+func waitForTx(t *testing.T, tx *transmitter.Tx, timeout time.Duration) string {
+	t.Helper()
+
+	select {
+	case msg := <-tx.Chan:
+		return msg
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for tx output")
+		return ""
+	}
+}

--- a/internal/igate/igate_beacon_test.go
+++ b/internal/igate/igate_beacon_test.go
@@ -182,21 +182,15 @@ func TestSendBeaconRfIgnoresSelfCollision(t *testing.T) {
 	})
 
 	select {
-	case retry := <-tx.Chan:
-		t.Fatalf("unexpected retry after self-collision: %q", retry)
-	case <-time.After(5 * time.Millisecond):
-	}
-
-	ig.markRx()
-	ig.observeBeacon(&aprs.Packet{
-		Src:     "N0CALL-7",
-		Payload: "SelfAware",
-	})
-
-	select {
 	case <-done:
 	case <-time.After(200 * time.Millisecond):
-		t.Fatalf("sendBeaconRf did not finish after acknowledging self-collision")
+		t.Fatalf("sendBeaconRf did not finish after acknowledging self collision via path")
+	}
+
+	select {
+	case retry := <-tx.Chan:
+		t.Fatalf("unexpected retry after self-collision: %q", retry)
+	default:
 	}
 
 	close(ig.stop)

--- a/internal/igate/igate_test.go
+++ b/internal/igate/igate_test.go
@@ -19,7 +19,7 @@ func TestIGate_startBeacon(t *testing.T) {
 		tx        *transmitter.Tx
 		logger    *log.Logger
 		Aprsis    *aprs.AprsIs
-		stop      chan bool
+		stop      chan struct{}
 	}
 	tests := []struct {
 		name          string
@@ -36,7 +36,7 @@ func TestIGate_startBeacon(t *testing.T) {
 				enableTx:  false,
 				tx:        &transmitter.Tx{},
 				Aprsis:    &aprs.AprsIs{},
-				stop:      make(chan bool),
+				stop:      make(chan struct{}),
 			},
 			wantErr:       true,
 			wantErrString: "rf-interval cannot be < 10m",
@@ -49,7 +49,7 @@ func TestIGate_startBeacon(t *testing.T) {
 				enableTx:  false,
 				tx:        &transmitter.Tx{},
 				Aprsis:    &aprs.AprsIs{},
-				stop:      make(chan bool),
+				stop:      make(chan struct{}),
 			},
 			wantErr:       true,
 			wantErrString: "beacon call-sign not configured",

--- a/internal/igate/igate_test.go
+++ b/internal/igate/igate_test.go
@@ -47,6 +47,31 @@ func TestIGate_startBeacon(t *testing.T) {
 			wantErrString: "rf-interval cannot be < 10m",
 		},
 		{
+			name: "additional rf beacon interval too short",
+			fields: fields{
+				cfg: config.IGate{
+					Beacon: config.Beacon{
+						Enabled: true,
+						ExtraRF: []config.RFBeacon{
+							{
+								Path:     "",
+								Interval: 5 * time.Minute,
+							},
+						},
+					},
+				},
+				callSign:  "N0CALL-10",
+				inputChan: make(chan string),
+				enableTx:  false,
+				tx:        &transmitter.Tx{},
+				logger:    mustLogger(t),
+				Aprsis:    &aprs.AprsIs{},
+				stop:      make(chan struct{}),
+			},
+			wantErr:       true,
+			wantErrString: "additional-rf-beacons interval cannot be < 10m",
+		},
+		{
 			name: "test no callsign",
 			fields: fields{
 				cfg: config.IGate{
@@ -82,7 +107,32 @@ func TestIGate_startBeacon(t *testing.T) {
 				},
 				callSign:  "N0CALL-10",
 				inputChan: make(chan string),
-				enableTx:  true,
+				enableTx:  false,
+				tx:        &transmitter.Tx{},
+				logger:    mustLogger(t),
+				Aprsis:    &aprs.AprsIs{},
+				stop:      make(chan struct{}),
+			},
+			wantErr: false,
+		},
+		{
+			name: "additional rf beacon without primary",
+			fields: fields{
+				cfg: config.IGate{
+					Beacon: config.Beacon{
+						Enabled: true,
+						ExtraRF: []config.RFBeacon{
+							{
+								Path:     "",
+								Interval: 10 * time.Minute,
+							},
+						},
+						DisableTCP: true,
+					},
+				},
+				callSign:  "N0CALL-10",
+				inputChan: make(chan string),
+				enableTx:  false,
 				tx:        &transmitter.Tx{},
 				logger:    mustLogger(t),
 				Aprsis:    &aprs.AprsIs{},

--- a/internal/multimon/multimon_test.go
+++ b/internal/multimon/multimon_test.go
@@ -1,0 +1,46 @@
+package multimon
+
+import "testing"
+
+func TestIsSelfMessage(t *testing.T) {
+	m := &Multimon{
+		stationCallsign: "N7RIX-10",
+	}
+
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "exact match",
+			msg:  "N7RIX-10>APRS:payload",
+			want: true,
+		},
+		{
+			name: "lowercase source",
+			msg:  "n7rix-10>APRS:payload",
+			want: true,
+		},
+		{
+			name: "different callsign",
+			msg:  "OTHER-1>APRS:payload",
+			want: false,
+		},
+		{
+			name: "missing source delimiter",
+			msg:  "INVALID FRAME",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.isSelfMessage(tt.msg)
+			if got != tt.want {
+				t.Fatalf("isSelfMessage(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
  - prioritize forwarding APRS-IS packets before ancillary processing
  - add RF beacon retry loop that backs off on detected collisions
  - cover the new beacon flow with unit tests for collision and success paths

  ## Testing
  - go test ./...