### PR TITLE
Refine packet cache dedupe logic

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/oorrwullie/go-igate/internal/cache"
 	"github.com/oorrwullie/go-igate/internal/capture"
@@ -96,7 +97,7 @@ func NewDigiGate(logger *log.Logger) (*DigiGate, error) {
 		txHandle = tx.Tx
 	}
 
-	appCache := cache.NewCache(cfg.CacheSize, ".cache.json")
+	appCache := cache.NewCache(cfg.CacheSize, ".cache.json", 30*time.Minute)
 
 	multimon = multimonpackage.New(cfg.Multimon, captureOutputChan, ps, appCache, txHandle, cfg.StationCallsign, logger)
 	err = multimon.Start()

--- a/app.go
+++ b/app.go
@@ -97,7 +97,7 @@ func NewDigiGate(logger *log.Logger) (*DigiGate, error) {
 		txHandle = tx.Tx
 	}
 
-	appCache := cache.NewCache(cfg.CacheSize, ".cache.json", 30*time.Minute)
+	appCache := cache.NewCache(cfg.CacheSize, ".cache.json", 60*time.Second)
 
 	multimon = multimonpackage.New(cfg.Multimon, captureOutputChan, ps, appCache, txHandle, cfg.StationCallsign, logger)
 	err = multimon.Start()

--- a/internal/aprs/packet_test.go
+++ b/internal/aprs/packet_test.go
@@ -33,3 +33,32 @@ func TestParsePacketWithThirdPartyPayload(t *testing.T) {
 		t.Fatalf("unexpected payload: got %q want %q", packet.Payload, wantPayload)
 	}
 }
+
+func TestPacketPosition(t *testing.T) {
+	packet, err := ParsePacket("CALL>APRS:!4010.30N/11137.60W#Test")
+	if err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	lat, lon, ok := packet.Position()
+	if !ok {
+		t.Fatalf("expected position to be parsed")
+	}
+
+	if lat < 40.17 || lat > 40.18 {
+		t.Fatalf("unexpected latitude %f", lat)
+	}
+
+	if lon > -111.62 || lon < -111.64 {
+		t.Fatalf("unexpected longitude %f", lon)
+	}
+
+	msgPacket, err := ParsePacket("CALL>APRS:>Status text")
+	if err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	if _, _, ok := msgPacket.Position(); ok {
+		t.Fatalf("expected no position for status report")
+	}
+}

--- a/internal/cache/README.md
+++ b/internal/cache/README.md
@@ -1,35 +1,28 @@
 ## Cache
-This implementation provides a scalable solution using a combination of an LRU cache and a Bloom Filter to efficiently manage APRS packet storage while reducing duplicate transmissions.
+An in-memory LRU cache with optional TTL persistence used to suppress duplicate APRS packets between decoders.
 
 ## Usage Example
 ```golang
 func main() {
-	cache := NewCache(1000, 10000, "cache.json") // Capacity of 1000 for LRU, Bloom filter size of 10,000 items
+    cache := NewCache(1000, "cache.json", 30*time.Minute)
 
-	// Example APRS entries
-	entries := []string{
-		"APRS: N7RIX-7>T0QPSP,WIDE1-1,WIDE2-1:`AYl\"<[/`\"C0}_3",
-		"APRS: N7RIX-7>T0QPSP,WIDE1-1,WIDE2-2:`AYl\"<[/`\"C0}_4",
-		"APRS: N7RIX-7>T0QPSP,WIDE1-1,WIDE2-3:`AYl\"<[/`\"C0}_5",
-		"APRS: N7RIX-7>T0QPSP,WIDE1-1,WIDE2-1:`AYl\"<[/`\"C0}_3", // Duplicate
-	}
+    entries := []string{
+        "N7RIX-7>T0QPSP,WIDE1-1,WIDE2-1:`AYl\"<[/*C0}_3",
+        "N7RIX-7>T0QPSP,WIDE1-1,WIDE2-2:`AYl\"<[/*C0}_4",
+        "N7RIX-7>T0QPSP,WIDE1-1,WIDE2-3:`AYl\"<[/*C0}_5",
+        "N7RIX-7>T0QPSP,WIDE1-1,WIDE2-1:`AYl\"<[/*C0}_3",
+    }
 
-	for _, entry := range entries {
-		isDuplicate := cache.Set(entry, entry)
-
-        if isDuplicate {
+    for _, entry := range entries {
+        if cache.Set(entry, time.Now()) {
             fmt.Println("Duplicate entry")
         }
-	}
+    }
 
-	// Check cache contents
-	for _, entry := range entries {
-		value, exists := cache.Get(entry)
-		if exists {
-			fmt.Printf("Entry found in cache: %v\n", value)
-		} else {
-			fmt.Printf("Entry not found in cache: %v\n", entry)
-		}
-	}
+    for _, entry := range entries {
+        if _, exists := cache.Get(entry); exists {
+            fmt.Println("Entry found:", entry)
+        }
+    }
 }
 ```

--- a/internal/cache/README.md
+++ b/internal/cache/README.md
@@ -4,7 +4,7 @@ An in-memory LRU cache with optional TTL persistence used to suppress duplicate 
 ## Usage Example
 ```golang
 func main() {
-    cache := NewCache(1000, "cache.json", 30*time.Minute)
+    cache := NewCache(1000, "cache.json", 60*time.Second)
 
     entries := []string{
         "N7RIX-7>T0QPSP,WIDE1-1,WIDE2-1:`AYl\"<[/*C0}_3",

--- a/internal/cache/lru.go
+++ b/internal/cache/lru.go
@@ -3,24 +3,18 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"io"
 	"os"
 	"sync"
+	"time"
 )
-
-type entry struct {
-	key string
-	val interface{}
-}
 
 type Cache struct {
 	capacity int
-	cache    map[string]interface{}
 	mu       sync.Mutex
 	filePath string
 	lru      *LRU
-	bloom    *BloomFilter
+	ttl      time.Duration
 }
 
 type LRU struct {
@@ -31,73 +25,18 @@ type LRU struct {
 }
 
 type node struct {
-	key  string
-	val  interface{}
-	prev *node
-	next *node
+	key       string
+	val       interface{}
+	prev      *node
+	next      *node
+	timestamp time.Time
 }
 
-type BloomFilter struct {
-	size     uint
-	hashFunc func([]byte) uint32
-	bitSet   []bool
-	mu       sync.Mutex
-}
-
-func NewBloomFilter(size uint) *BloomFilter {
-	return &BloomFilter{
-		size:     size,
-		hashFunc: fnvHash,
-		bitSet:   make([]bool, size),
-	}
-}
-
-func (bf *BloomFilter) Add(data []byte) {
-	bf.mu.Lock()
-	defer bf.mu.Unlock()
-
-	for _, pos := range bf.getPositions(data) {
-		bf.bitSet[pos] = true
-	}
-}
-
-func (bf *BloomFilter) Test(data []byte) bool {
-	bf.mu.Lock()
-	defer bf.mu.Unlock()
-
-	for _, pos := range bf.getPositions(data) {
-		if !bf.bitSet[pos] {
-			return false
-		}
+func NewCache(capacity int, filePath string, ttl time.Duration) *Cache {
+	if capacity <= 0 {
+		capacity = 1
 	}
 
-	return true
-}
-
-func (bf *BloomFilter) getPositions(data []byte) []uint {
-	hash1, hash2 := bf.hash(data)
-	return []uint{hash1 % bf.size, hash2 % bf.size}
-}
-
-func (bf *BloomFilter) hash(data []byte) (uint, uint) {
-	h := fnv.New32a()
-	h.Write(data)
-	hash1 := uint(h.Sum32())
-
-	h.Reset()
-	h.Write(data)
-	hash2 := uint(h.Sum32())
-
-	return hash1, hash2
-}
-
-func fnvHash(data []byte) uint32 {
-	h := fnv.New32a()
-	h.Write(data)
-	return h.Sum32()
-}
-
-func NewCache(capacity int, filePath string) *Cache {
 	lru := &LRU{
 		cache:    make(map[string]*node),
 		capacity: capacity,
@@ -105,30 +44,138 @@ func NewCache(capacity int, filePath string) *Cache {
 
 	cache := &Cache{
 		capacity: capacity,
-		cache:    make(map[string]interface{}),
-		lru:      lru,
-		bloom:    NewBloomFilter(uint(capacity * 10)),
 		filePath: filePath,
+		lru:      lru,
+		ttl:      ttl,
 	}
 
-	cache.loadFromFile()
+	_ = cache.loadFromFile()
 	fmt.Println("Loaded cache")
 
 	return cache
 }
 
-func (l *LRU) get(key string) (interface{}, bool) {
-	if node, exists := l.cache[key]; exists {
-		l.moveToFront(node)
-		return node.val, exists
+func (c *Cache) Get(key string) (interface{}, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	node, exists := c.lru.cache[key]
+	if !exists {
+		return nil, false
 	}
 
-	return nil, false
+	if c.ttl > 0 && time.Since(node.timestamp) > c.ttl {
+		c.lru.removeNode(node)
+		delete(c.lru.cache, key)
+		return nil, false
+	}
+
+	c.lru.moveToFront(node)
+	return node.val, true
+}
+
+func (c *Cache) Set(key string, value interface{}) (duplicate bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if node, exists := c.lru.cache[key]; exists {
+		if c.ttl <= 0 || time.Since(node.timestamp) <= c.ttl {
+			node.timestamp = time.Now()
+			node.val = value
+			c.lru.moveToFront(node)
+			return true
+		}
+		c.lru.removeNode(node)
+		delete(c.lru.cache, key)
+	}
+
+	if c.ttl > 0 {
+		c.pruneExpiredLocked()
+	}
+
+	c.lru.set(key, value)
+	if err := c.saveToFile(); err != nil && c.filePath != "" {
+		fmt.Println("Error saving cache:", err)
+	}
+
+	return false
+}
+
+func (c *Cache) pruneExpiredLocked() {
+	if c.ttl <= 0 {
+		return
+	}
+
+	now := time.Now()
+	for key, node := range c.lru.cache {
+		if now.Sub(node.timestamp) > c.ttl {
+			c.lru.removeNode(node)
+			delete(c.lru.cache, key)
+		}
+	}
+}
+
+func (c *Cache) saveToFile() error {
+	if c.filePath == "" {
+		return nil
+	}
+
+	file, err := os.Create(c.filePath)
+	if err != nil {
+		return fmt.Errorf("error creating cache file: %w", err)
+	}
+	defer file.Close()
+
+	data := make(map[string]int64, len(c.lru.cache))
+	for k, n := range c.lru.cache {
+		data[k] = n.timestamp.UnixNano()
+	}
+
+	if err := json.NewEncoder(file).Encode(data); err != nil {
+		return fmt.Errorf("error encoding cache data to JSON: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Cache) loadFromFile() error {
+	if c.filePath == "" {
+		return nil
+	}
+
+	file, err := os.Open(c.filePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error opening cache file: %w", err)
+		}
+		return nil
+	}
+	defer file.Close()
+
+	data := make(map[string]int64)
+	if err := json.NewDecoder(file).Decode(&data); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return fmt.Errorf("error decoding cache data from JSON: %w", err)
+	}
+
+	now := time.Now()
+	for k, ts := range data {
+		timestamp := time.Unix(0, ts)
+		if c.ttl > 0 && now.Sub(timestamp) > c.ttl {
+			continue
+		}
+		c.lru.setWithTimestamp(k, timestamp)
+	}
+
+	return nil
 }
 
 func (l *LRU) set(key string, val interface{}) {
 	if node, exists := l.cache[key]; exists {
 		node.val = val
+		node.timestamp = time.Now()
 		l.moveToFront(node)
 		return
 	}
@@ -138,8 +185,24 @@ func (l *LRU) set(key string, val interface{}) {
 	}
 
 	newNode := &node{
-		key: key,
-		val: val,
+		key:       key,
+		val:       val,
+		timestamp: time.Now(),
+	}
+
+	l.cache[key] = newNode
+	l.addToFront(newNode)
+}
+
+func (l *LRU) setWithTimestamp(key string, ts time.Time) {
+	if len(l.cache) >= l.capacity {
+		l.evictTail()
+	}
+
+	newNode := &node{
+		key:       key,
+		val:       ts,
+		timestamp: ts,
 	}
 
 	l.cache[key] = newNode
@@ -149,11 +212,25 @@ func (l *LRU) set(key string, val interface{}) {
 func (l *LRU) evictTail() {
 	if l.tail != nil {
 		delete(l.cache, l.tail.key)
-		if l.tail.prev != nil {
-			l.tail.prev.next = nil
-		}
-		l.tail = l.tail.prev
+		l.removeNode(l.tail)
 	}
+}
+
+func (l *LRU) removeNode(n *node) {
+	if n.prev != nil {
+		n.prev.next = n.next
+	}
+	if n.next != nil {
+		n.next.prev = n.prev
+	}
+	if l.head == n {
+		l.head = n.next
+	}
+	if l.tail == n {
+		l.tail = n.prev
+	}
+	n.prev = nil
+	n.next = nil
 }
 
 func (l *LRU) moveToFront(n *node) {
@@ -161,27 +238,12 @@ func (l *LRU) moveToFront(n *node) {
 		return
 	}
 
-	if n.prev != nil {
-		n.prev.next = n.next
-	}
-
-	if n.next != nil {
-		n.next.prev = n.prev
-	}
-
-	if n == l.tail {
-		l.tail = n.prev
-	}
-
+	l.removeNode(n)
 	n.next = l.head
-	n.prev = nil
-
 	if l.head != nil {
 		l.head.prev = n
 	}
-
 	l.head = n
-
 	if l.tail == nil {
 		l.tail = n
 	}
@@ -197,89 +259,4 @@ func (l *LRU) addToFront(n *node) {
 	n.next = l.head
 	l.head.prev = n
 	l.head = n
-}
-
-func (c *Cache) Get(key string) (interface{}, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if value, exists := c.lru.get(key); exists {
-		return value, true
-	}
-
-	return nil, false
-}
-
-func (c *Cache) Set(key string, value interface{}) (duplicate bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.bloom.Test([]byte(key)) {
-		return true
-	}
-
-	c.lru.set(key, value)
-	c.bloom.Add([]byte(key))
-	c.saveToFile()
-
-	return false
-}
-
-func (c *Cache) saveToFile() error {
-	if c.filePath == "" {
-		return fmt.Errorf("filePath cannot be empty")
-	}
-
-	file, err := os.Create(c.filePath)
-	if err != nil {
-		return fmt.Errorf("Error creating cache file: %v", err)
-	}
-	defer file.Close()
-
-	data := make(map[string]interface{})
-
-	for k, v := range c.lru.cache {
-		data[k] = v.val
-	}
-
-	j := json.NewEncoder(file)
-	err = j.Encode(data)
-
-	if err != nil {
-		return fmt.Errorf("Error encoding cache data to JSON: %v", err)
-	}
-
-	return nil
-}
-
-func (c *Cache) loadFromFile() error {
-	if c.filePath == "" {
-		return fmt.Errorf("filePath cannot be empty")
-	}
-
-	file, err := os.Open(c.filePath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("Error opening cache file: %v", err)
-		}
-		return nil
-	}
-	defer file.Close()
-
-	data := make(map[string]interface{})
-
-	err = json.NewDecoder(file).Decode(&data)
-	if err != nil {
-		if err == io.EOF {
-			return nil
-		}
-		return fmt.Errorf("Error decoding cache data from JSON: %v", err)
-	}
-
-	for k, v := range data {
-		fmt.Printf("Cache key: %s value: %v\n", k, v)
-		c.Set(k, v)
-	}
-
-	return nil
 }

--- a/internal/igate/igate_test.go
+++ b/internal/igate/igate_test.go
@@ -1,6 +1,7 @@
 package igate
 
 import (
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -218,6 +219,33 @@ func TestIGate_startBeacon(t *testing.T) {
 				close(i.stop)
 			}
 		})
+	}
+}
+
+func TestParseRangeFilter(t *testing.T) {
+	filter, err := parseRangeFilter("r/40.17/-111.63/200 foo/bar")
+	if err != nil {
+		t.Fatalf("parseRangeFilter returned error: %v", err)
+	}
+
+	if filter == nil {
+		t.Fatalf("expected range filter")
+	}
+
+	if math.Abs(filter.latCenter-40.17) > 1e-6 {
+		t.Fatalf("unexpected lat %f", filter.latCenter)
+	}
+
+	if math.Abs(filter.lonCenter+111.63) > 1e-6 {
+		t.Fatalf("unexpected lon %f", filter.lonCenter)
+	}
+
+	if filter.radiusKm != 200 {
+		t.Fatalf("unexpected radius %f", filter.radiusKm)
+	}
+
+	if _, err := parseRangeFilter("r/invalid"); err == nil {
+		t.Fatalf("expected error for invalid filter")
 	}
 }
 

--- a/internal/multimon/multimon.go
+++ b/internal/multimon/multimon.go
@@ -106,7 +106,7 @@ func (m *Multimon) Start() error {
 					continue
 				}
 
-				duplicate := m.cache.Set(msg, time.Now())
+				duplicate := m.cache.Set(normalized, time.Now())
 				if duplicate && !m.isSelfMessage(normalized) {
 					m.logger.Info("Duplicate packet received: ", msg)
 					continue


### PR DESCRIPTION
## Summary of Changes
  - Scrubbed the duplicate cache: we now dedupe on normalized frames, confirm
    hits in the LRU before declaring “duplicate”, and expire entries after 60 s
    so new traffic doesn’t get suppressed.
  - Extended the IGate with optional geo filtering—if the APRS-IS filter
    contains an r/lat/lon/radius token, we only upload frames inside that
    circle. Everything else is allowed through as long as no filter is
    configured.
  - Added helpers/tests for parsing uncompressed positions, range filters, and
    the new behavior.