### PR TITLE
Add optional soundcard capture mode

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -26,6 +26,8 @@ digipeater:
 soundcard-input-name: ""
 # soundcard-output-name is the name of the device to use for audio output. If empty, the system default device will be used.
 soundcard-output-name: ""
+# set to true to bypass the SDR and use the soundcard input for receive
+soundcard-capture-enabled: false
 sdr:
   #Set to true to enable using an RTL-SDR dongle
   enabled: true

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -12,9 +12,13 @@ type Capture interface {
 }
 
 func New(cfg config.Config, outputChan chan []byte, logger *log.Logger) (Capture, error) {
-	if cfg.Sdr.Enabled {
-		return NewSdrCapture(cfg.Sdr, outputChan, logger)
-	}
+    if cfg.SoundcardCapture {
+        return NewSoundcardCapture(cfg, outputChan, logger)
+    }
 
-	return NewSoundcardCapture(cfg, outputChan, logger)
+    if cfg.Sdr.Enabled {
+        return NewSdrCapture(cfg.Sdr, outputChan, logger)
+    }
+
+    return NewSoundcardCapture(cfg, outputChan, logger)
 }

--- a/internal/config/cfg.go
+++ b/internal/config/cfg.go
@@ -21,6 +21,7 @@ type (
 		StationCallsign     string      `yaml:"station-callsign"`
 		SoundcardInputName  string      `yaml:"soundcard-input-name"`
 		SoundcardOutputName string      `yaml:"soundcard-output-name"`
+		SoundcardCapture    bool        `yaml:"soundcard-capture-enabled"`
 	}
 
 	IGate struct {


### PR DESCRIPTION
  ### Branch

  - feature/soundcard-capture pushed to origin

  ### Changes

  - Added soundcard-capture-enabled flag to config.yml.example so users can opt
    into audio RX.
  - config.Config now carries that flag, and capture.New checks it before
    spinning up the RTL-SDR. If soundcard capture is enabled (or SDR disabled),
    we automatically fall back to the existing PortAudio-based path.

  ### Tests / Build

  - go test ./...
  - make

  ### PR description (ready to paste)

  ## Summary
  - add `soundcard-capture-enabled` to the config so operators can run RX
  directly from an audio device instead of an RTL-SDR
  - teach the capture factory to honor that flag (and to fall back to the
  soundcard path when the SDR is disabled), so no SDR configuration is required
  for soundcard-only setups

  ## Testing
  - go test ./...
  - make

  Let me know if you want to extend the docs or add a quick note in the README
  about the new option.