### PR TITLE
Let APRS‑IS gating reflect first‑receiver paths on aprs.fi

### DIFF
--- a/app.go
+++ b/app.go
@@ -112,6 +112,18 @@ func NewDigiGate(logger *log.Logger) (*DigiGate, error) {
 		}
 	}
 
+	var gateRewriter *digipeater.Rewriter
+	if cfg.IGate.GateDigipeatedPath {
+		if cfg.DigipeaterEnabled {
+			gateRewriter, err = digipeater.NewRewriter(cfg.StationCallsign, cfg.Digipeater)
+			if err != nil {
+				return nil, fmt.Errorf("Error creating digipeater rewriter: %v", err)
+			}
+		} else {
+			logger.Warn("igate.gate-digipeated-path enabled but digipeater is disabled; using original RF path")
+		}
+	}
+
 	if cfg.DigipeaterEnabled {
 		if txHandle == nil {
 			logger.Warn("Digipeater enabled but transmitter is disabled; skipping digipeater")
@@ -121,6 +133,10 @@ func NewDigiGate(logger *log.Logger) (*DigiGate, error) {
 				return nil, fmt.Errorf("Error creating digipeater: %v", err)
 			}
 		}
+	}
+
+	if ig != nil && gateRewriter != nil {
+		ig.SetDigiRewriter(gateRewriter)
 	}
 
 	dg := &DigiGate{

--- a/config.yml.example
+++ b/config.yml.example
@@ -65,6 +65,10 @@ transmitter:
 igate:
   # enabled: set to true to enable DigiGate to act as an iGate.
   enabled: true
+  # gate self-originated RF packets to APRS-IS (disabled by default).
+  forward-self-rf: false
+  # when enabled, APRS-IS gating uses the digipeated path when this station would digipeat.
+  gate-digipeated-path: false
   beacon:
     # enable to send beacon messages
     enabled: false

--- a/internal/config/cfg.go
+++ b/internal/config/cfg.go
@@ -25,10 +25,11 @@ type (
 	}
 
 	IGate struct {
-		Enabled       bool   `yaml:"enabled"`
-		Aprsis        AprsIs `yaml:"aprsis"`
-		Beacon        Beacon `yaml:"beacon"`
-		ForwardSelfRF bool   `yaml:"forward-self-rf"`
+		Enabled            bool   `yaml:"enabled"`
+		Aprsis             AprsIs `yaml:"aprsis"`
+		Beacon             Beacon `yaml:"beacon"`
+		ForwardSelfRF      bool   `yaml:"forward-self-rf"`
+		GateDigipeatedPath bool   `yaml:"gate-digipeated-path"`
 	}
 
 	Sdr struct {

--- a/internal/digipeater/rewriter.go
+++ b/internal/digipeater/rewriter.go
@@ -1,0 +1,129 @@
+package digipeater
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/oorrwullie/go-igate/internal/aprs"
+	"github.com/oorrwullie/go-igate/internal/config"
+)
+
+// Rewriter applies digipeater path rules without transmitting.
+type Rewriter struct {
+	callsign      string
+	callsignUpper string
+	aliasRules    []*regexp.Regexp
+	wideRules     []*regexp.Regexp
+	ssnPrefixes   map[string]struct{}
+}
+
+func NewRewriter(callsign string, cfg config.Digipeater) (*Rewriter, error) {
+	if callsign == "" {
+		return nil, fmt.Errorf("station callsign not configured")
+	}
+
+	alias, err := compilePatterns(cfg.AliasPatterns)
+	if err != nil {
+		return nil, fmt.Errorf("invalid alias pattern: %w", err)
+	}
+
+	wide, err := compilePatterns(cfg.WidePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("invalid wide pattern: %w", err)
+	}
+
+	ssnPrefixes := make(map[string]struct{}, len(cfg.SSnPrefixes))
+	for _, prefix := range cfg.SSnPrefixes {
+		if prefix == "" {
+			continue
+		}
+		ssnPrefixes[strings.ToUpper(prefix)] = struct{}{}
+	}
+
+	return &Rewriter{
+		callsign:      callsign,
+		callsignUpper: strings.ToUpper(callsign),
+		aliasRules:    alias,
+		wideRules:     wide,
+		ssnPrefixes:   ssnPrefixes,
+	}, nil
+}
+
+// Rewrite updates the packet path to reflect a local digipeat.
+// Returns true when the path is rewritten.
+func (r *Rewriter) Rewrite(packet *aprs.Packet) bool {
+	if packet == nil {
+		return false
+	}
+
+	if strings.EqualFold(packet.Src, r.callsign) {
+		return false
+	}
+
+	if len(packet.Path) == 0 {
+		return false
+	}
+
+	firstIdx := firstUnusedPathIndex(packet.Path)
+	if firstIdx == -1 {
+		return false
+	}
+
+	return r.rewritePath(packet, firstIdx)
+}
+
+func (r *Rewriter) rewritePath(packet *aprs.Packet, idx int) bool {
+	component := strings.TrimSpace(packet.Path[idx])
+	if component == "" {
+		return false
+	}
+
+	bare := strings.TrimSuffix(component, "*")
+
+	if strings.EqualFold(bare, r.callsign) {
+		packet.Path[idx] = r.callsignUpper + "*"
+		return true
+	}
+
+	for _, re := range r.aliasRules {
+		if re.MatchString(bare) {
+			packet.Path[idx] = r.callsignUpper + "*"
+			return true
+		}
+	}
+
+	for _, re := range r.wideRules {
+		if re.MatchString(bare) {
+			base, remaining, ok := parseHop(bare)
+			if !ok || remaining <= 0 {
+				return false
+			}
+			base = strings.ToUpper(base)
+
+			if prefix, ok := ssnPrefix(base); ok && !r.allowSSnPrefix(prefix) {
+				return false
+			}
+
+			if remaining == 1 {
+				packet.Path[idx] = r.callsignUpper + "*"
+				return true
+			}
+
+			packet.Path[idx] = fmt.Sprintf("%s-%d", base, remaining-1)
+			packet.Path = insertBefore(packet.Path, idx, r.callsignUpper+"*")
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Rewriter) allowSSnPrefix(prefix string) bool {
+	if len(r.ssnPrefixes) == 0 {
+		return false
+	}
+
+	_, ok := r.ssnPrefixes[strings.ToUpper(prefix)]
+	return ok
+}

--- a/internal/digipeater/rewriter_test.go
+++ b/internal/digipeater/rewriter_test.go
@@ -1,0 +1,61 @@
+package digipeater
+
+import (
+	"testing"
+
+	"github.com/oorrwullie/go-igate/internal/aprs"
+	"github.com/oorrwullie/go-igate/internal/config"
+)
+
+func TestRewriter(t *testing.T) {
+	tests := []struct {
+		name        string
+		frame       string
+		wantPath    []string
+		wantRewrite bool
+	}{
+		{
+			name:        "rewrite-wide1-1",
+			frame:       "CALL1>APRS,WIDE1-1:/123456h4903.50N/07201.75W-Test message",
+			wantPath:    []string{"N0CALL-1*"},
+			wantRewrite: true,
+		},
+		{
+			name:        "skip-self",
+			frame:       "N0CALL-1>APRS,WIDE1-1:/123456h4903.50N/07201.75W-Test message",
+			wantPath:    []string{"WIDE1-1"},
+			wantRewrite: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewriter, err := NewRewriter("N0CALL-1", config.Digipeater{
+				AliasPatterns: []string{`^WIDE1-1$`},
+				WidePatterns:  []string{`^WIDE[1-7]-[1-7]$`},
+			})
+			if err != nil {
+				t.Fatalf("failed to create rewriter: %v", err)
+			}
+
+			packet, err := aprs.ParsePacket(tt.frame)
+			if err != nil {
+				t.Fatalf("failed to parse packet: %v", err)
+			}
+
+			gotRewrite := rewriter.Rewrite(packet)
+			if gotRewrite != tt.wantRewrite {
+				t.Fatalf("unexpected rewrite result: %v", gotRewrite)
+			}
+
+			if len(packet.Path) != len(tt.wantPath) {
+				t.Fatalf("unexpected rewritten path: %#v", packet.Path)
+			}
+			for idx, want := range tt.wantPath {
+				if packet.Path[idx] != want {
+					t.Fatalf("unexpected rewritten path: %#v", packet.Path)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION

  On aprs.fi, the green “first receiver” line appears only when the packet path
  reflects the first RF hop. With the current iGate behavior, gated packets
  always show a purple iGate hop, even when this station was the first receiver.
  This change makes it possible to align the APRS‑IS path with digipeater rules
  so aprs.fi can show the green first‑receiver segment without changing RF