### PR TITLE
feat: forward telemetry to APRS-IS

### DIFF
--- a/internal/aprs/packet.go
+++ b/internal/aprs/packet.go
@@ -258,7 +258,7 @@ func (t PacketType) String() string {
 func (t PacketType) ForwardToAprsIs() bool {
 	switch t {
 	case PositionReport, StatusReport, Message,
-		WeatherReport, ObjectReport, ItemReport:
+		Telemetry, WeatherReport, ObjectReport, ItemReport:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
  - forward telemetry packets to APRS-IS so they appear on APRS-IS backed maps (e.g., aprs.to)
 
## Testing
  - go test ./... (fails locally: missing portaudio-2.0 in build environment)