### PR TITLE
fix: gate digipeated path only when self hop present

### DIFF
--- a/internal/igate/igate.go
+++ b/internal/igate/igate.go
@@ -279,7 +279,7 @@ func (i *IGate) forwardPackets() error {
 				continue
 			}
 
-			uploadFrame := formatForAprsIs(packet, i.callSign)
+			uploadFrame := formatForAprsIs(packet, i.callSign, i.enableTx)
 			fmt.Printf("uploading APRS-IS packet: %v\n", uploadFrame)
 			if i.aprsisUpload != nil {
 				if err := i.aprsisUpload(uploadFrame); err != nil {
@@ -489,7 +489,7 @@ func buildBeaconFrame(callSign, path, comment string) string {
 	return builder.String()
 }
 
-func formatForAprsIs(packet *aprs.Packet, callSign string) string {
+func formatForAprsIs(packet *aprs.Packet, callSign string, txEnabled bool) string {
 	var builder strings.Builder
 
 	callSign = strings.ToUpper(strings.TrimSpace(callSign))
@@ -500,7 +500,11 @@ func formatForAprsIs(packet *aprs.Packet, callSign string) string {
 
 	path := append([]string{}, packet.Path...)
 	if !containsAprsIsHop(path) && callSign != "" {
-		path = append(path, "TCPIP*", "qAR", callSign)
+		qConstruct := "qAR"
+		if txEnabled {
+			qConstruct = "qAO"
+		}
+		path = append(path, "TCPIP*", qConstruct, callSign)
 	}
 
 	if len(path) > 0 {

--- a/internal/igate/igate_test.go
+++ b/internal/igate/igate_test.go
@@ -382,9 +382,14 @@ func TestListenForMessagesUsesDigipeatedPathWhenEnabled(t *testing.T) {
 		wantPath []string
 	}{
 		{
-			name:     "rewrite-wide1-1",
+			name:     "skip-rewrite-when-not-self-hop",
 			frame:    "CALL1>APRS,WIDE1-1:/123456h4903.50N/07201.75W-Test message",
-			wantPath: []string{"N0CALL-1*"},
+			wantPath: []string{"WIDE1-1"},
+		},
+		{
+			name:     "rewrite-when-self-hop-present",
+			frame:    "CALL1>APRS,N0CALL-1*,WIDE1-1:/123456h4903.50N/07201.75W-Test message",
+			wantPath: []string{"N0CALL-1*", "N0CALL-1*"},
 		},
 	}
 


### PR DESCRIPTION
## Why
When gate-digipeated-path is enabled, the iGate was rewriting every forwarded RF packet as if this station had digipeated it. That can make APRS-IS paths show this station as the first RF hop even when the packet actually arrived after other digipeaters, which misrepresents the RF route and affects aprs.fi path coloring.

This change limits the rewrite to packets that already include this station in the RF path, so we only rewrite when we actually participated as a digipeater. This preserves correct hop semantics while still supporting the fill-in case.