### PR TITLE
fix: omit TCPIP* on RF-gated packets

### DIFF
--- a/internal/igate/igate.go
+++ b/internal/igate/igate.go
@@ -504,7 +504,7 @@ func formatForAprsIs(packet *aprs.Packet, callSign string, txEnabled bool) strin
 		if txEnabled {
 			qConstruct = "qAO"
 		}
-		path = append(path, "TCPIP*", qConstruct, callSign)
+		path = append(path, qConstruct, callSign)
 	}
 
 	if len(path) > 0 {

--- a/internal/igate/igate_test.go
+++ b/internal/igate/igate_test.go
@@ -470,13 +470,13 @@ func TestFormatForAprsIsQConstruct(t *testing.T) {
 			name: "adds-qao-when-tx-enabled",
 			tx:   true,
 			path: []string{"WIDE1-1"},
-			want: "CALL1>APRS,WIDE1-1,TCPIP*,qAO,N0CALL-10:" + payload,
+			want: "CALL1>APRS,WIDE1-1,qAO,N0CALL-10:" + payload,
 		},
 		{
 			name: "adds-qar-when-tx-disabled",
 			tx:   false,
 			path: []string{"WIDE1-1"},
-			want: "CALL1>APRS,WIDE1-1,TCPIP*,qAR,N0CALL-10:" + payload,
+			want: "CALL1>APRS,WIDE1-1,qAR,N0CALL-10:" + payload,
 		},
 		{
 			name: "does-not-duplicate-when-aprs-is-hop-present",


### PR DESCRIPTION
## Why
APRS-IS iGate guidance says RF→APRS-IS packets should not have their RF path modified except to append the q-construct and iGate callsign. Adding TCPIP* is not required for RF-gated packets and produces a different path style than common iGate implementations (e.g., Direwolf). 

This change omits TCPIP* for RF-gated packets and appends only qAO/qAR + callsign, aligning the output with the APRS-IS guidance and with widely-used iGate behavior.